### PR TITLE
Add meetings.json and auto-fill script for upcoming and past meetings

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,103 +1,156 @@
 <!DOCTYPE html>
 <html lang="en">
+
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>🤖💬 + 📚 + ☕️ | ChatGPT@ascii</title>
-    <link rel="stylesheet" href="simple.min.css">
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>🤖💬 + 📚 + ☕️ | ChatGPT@ascii</title>
+  <link rel="stylesheet" href="simple.min.css">
+
+  <script defer>
+    fetch('meetings.json')
+      .then(response => response.json())
+      .then(data => {
+        document.getElementById("next-meeting-date").textContent = data.nextMeeting.date;
+        document.getElementById("next-meeting-time").textContent = data.nextMeeting.time;
+        document.getElementById("next-meeting-title").textContent = data.nextMeeting.paperTitle;
+        document.getElementById("next-meeting-link").href = data.nextMeeting.paperLink;
+
+        let pastMeetingsList = document.getElementById("past-meetings-list");
+        data.pastMeetings.forEach(meeting => {
+          pastMeetingsList.innerHTML += `
+          <li>${meeting.date}, ${meeting.time} - <a href="${meeting.paperLink}">${meeting.paperTitle}</a></li>
+        `;
+        });
+      });
+  </script>
 </head>
+
 <body>
   <header>
 
     <h2>ChatGPT Reading Group @ ascii</h2>
-      <p>🤖💬 + 📚 + ☕️</p>
+    <p>🤖💬 + 📚 + ☕️</p>
   </header>
 
   <main>
+    <section>
+      <!-- Nächstes Treffen wird auto-filled durch meetings.json -->
+      <h4>Nächstes Treffen</h4>
+      <p id="next-meeting">
+        Das nächste Treffen findet am <span id="next-meeting-date">...</span> um <span id="next-meeting-time">...</span>
+        statt. Bitte lest bis dahin <a id="next-meeting-link" href="#">"<span id="next-meeting-title">...</span>"</a>.
+      </p>
+    </section>
+
     <p>Hallo zusammen!</p>
     <p>
-        Es gab mal die Idee, gemeinsam die grundlegenden Paper, auf denen ChatGPT aufbaut, zu lesen und drüber
-        zu reden. Das Ganze ist jetzt keine ascii-interne Veranstaltung, aber ich hatte im ascii schonmal mit Leuten
-        darüber gesprochen und das Interesse war scheinbar da. Um das mal zu besprechen, würde ich vorschlagen,
-        dass wir uns mal im ascii treffen. Danach können wir auch schauen, ob/wie wir es weiter bewerben wollen.
-        Das ascii als Café scheint mir aber erstmal ein geeigneter Ort für so eine Veranstaltung zu sein.
+      Es gab mal die Idee, gemeinsam die grundlegenden Paper, auf denen ChatGPT aufbaut, zu lesen und drüber
+      zu reden. Das Ganze ist jetzt keine ascii-interne Veranstaltung, aber ich hatte im ascii schonmal mit Leuten
+      darüber gesprochen und das Interesse war scheinbar da. Um das mal zu besprechen, würde ich vorschlagen,
+      dass wir uns mal im ascii treffen. Danach können wir auch schauen, ob/wie wir es weiter bewerben wollen.
+      Das ascii als Café scheint mir aber erstmal ein geeigneter Ort für so eine Veranstaltung zu sein.
     </p>
-      <p>
-          Für ein erstes Treffen habe ich ein dudle zur Terminfindung rum geschickt. Wer das nicht bekommen hat, kann
-          gerne eine E-Mail an <code>reading-group(at)deep.cooking</code> schicken. Das erste Treffen kann auch erstmal rein
-          organisatorisch sein. Dann können wir mal sehen, wie viele wir eigentlich sind und ob das Format (siehe unten)
-          so passt. Nur der thematische Fokus ist fest.
-      </p>
+    <p>
+      Für ein erstes Treffen habe ich ein dudle zur Terminfindung rum geschickt. Wer das nicht bekommen hat, kann
+      gerne eine E-Mail an <code>reading-group(at)deep.cooking</code> schicken. Das erste Treffen kann auch erstmal rein
+      organisatorisch sein. Dann können wir mal sehen, wie viele wir eigentlich sind und ob das Format (siehe unten)
+      so passt. Nur der thematische Fokus ist fest.
+    </p>
 
-      <h4>"Reading Group"</h4>
-      <p>
-          Die Idee wäre, dass wir uns regelmäßig (zwei wöchentlich?) zusammen setzen. Pro Termin gibt es ein Paper o.ä.,
-          das <b>alle vorher lesen</b> und im Idealfall auch direkt ein paar offene Punkte, Unklarheiten oder sonstige Fragen
-          aufschreiben. Eine Person stellt das Paper dann anhand von ein paar Slides vor (da reichen auch die
-          Abbildungen und Tabellen in eine Präsentation.). Wichtig ist eben, dass wir für jedes Paper eine/n Verantwortliche/n
-          haben, um Fragen zu stellen und ein bisschen den Termin zu strukturieren. Das ist aber auch einfacher als es
-          klingt :) Das erste Papier kann ich gerne selbst übernehmen.
-      </p>
+    <h4>"Reading Group"</h4>
+    <p>
+      Die Idee wäre, dass wir uns regelmäßig (zwei wöchentlich?) zusammen setzen. Pro Termin gibt es ein Paper o.ä.,
+      das <b>alle vorher lesen</b> und im Idealfall auch direkt ein paar offene Punkte, Unklarheiten oder sonstige
+      Fragen
+      aufschreiben. Eine Person stellt das Paper dann anhand von ein paar Slides vor (da reichen auch die
+      Abbildungen und Tabellen in eine Präsentation.). Wichtig ist eben, dass wir für jedes Paper eine/n
+      Verantwortliche/n
+      haben, um Fragen zu stellen und ein bisschen den Termin zu strukturieren. Das ist aber auch einfacher als es
+      klingt :) Das erste Papier kann ich gerne selbst übernehmen.
+    </p>
 
-      <h5>
-          Fokus
-      </h5>
-      <p>
-          Als Fokus für die Reading Group hätte ich, wie oben geschrieben, gerne alles was irgendwie mit ChatGPT und
-          den aktuellen Sprachmodellen, die für Chats und Co. benutzt werden, zu tun hat. Es gibt ja eine Reihe von
-          Weiterentwicklungen und Verbesserungen. Die würde ich mir gerne mal anschauen.
-      </p>
+    <h5>
+      Fokus
+    </h5>
+    <p>
+      Als Fokus für die Reading Group hätte ich, wie oben geschrieben, gerne alles was irgendwie mit ChatGPT und
+      den aktuellen Sprachmodellen, die für Chats und Co. benutzt werden, zu tun hat. Es gibt ja eine Reihe von
+      Weiterentwicklungen und Verbesserungen. Die würde ich mir gerne mal anschauen.
+    </p>
 
-      <p>
-          Das Ganze soll also <b>keine Lehrveranstaltung</b> sein, auch <b>kein Programmierkurs</b> oder ähnliches. Einfach nur Paper
-          lesen und dann bei einem Kaffee, Tee oder einem Kaltgetränk darüber reden.
-      </p>
+    <p>
+      Das Ganze soll also <b>keine Lehrveranstaltung</b> sein, auch <b>kein Programmierkurs</b> oder ähnliches. Einfach
+      nur Paper
+      lesen und dann bei einem Kaffee, Tee oder einem Kaltgetränk darüber reden.
+    </p>
 
-      <h5>
-          Paper
-      </h5>
-      <p>
-        Als Paper würde ich folgende vorschlagen (nicht zwingend in der Reihenfolge):
-      </p>
+    <h5>
+      Paper
+    </h5>
+    <p>
+      Als Paper würde ich folgende vorschlagen (nicht zwingend in der Reihenfolge):
+    </p>
 
-      <ul>
-          <li>Transformers: Attention is All You Need: <a href="https://arxiv.org/pdf/1706.03762.pdf" target="_blank" rel="noopener noreferrer">https://arxiv.org/pdf/1706.03762.pdf</a></li>
-          <li>GPT-3: <a href="https://arxiv.org/pdf/2005.14165.pdf" target="_blank" rel="noopener noreferrer">https://arxiv.org/pdf/2005.14165.pdf</a></li>
-          <li>InstructGPT: <a href="https://arxiv.org/pdf/2203.02155.pdf" target="_blank" rel="noopener noreferrer">https://arxiv.org/pdf/2203.02155.pdf</a></li>
-          <li>Alpaca: A Strong, Replicable Instruction-Following Model: <a href="https://crfm.stanford.edu/2023/03/13/alpaca.html" target="_blank" rel="noopener noreferrer">https://crfm.stanford.edu/2023/03/13/alpaca.html</a></li>
-          <li>Vicuna: <a href="https://lmsys.org/blog/2023-03-30-vicuna/" target="_blank" rel="noopener noreferrer">https://lmsys.org/blog/2023-03-30-vicuna/</a></li>
-          <li>LoRA: Low-Rank Adaptation of Large Language Models: <a href="https://arxiv.org/pdf/2106.09685.pdf" target="_blank" rel="noopener noreferrer">https://arxiv.org/pdf/2106.09685.pdf</a></li>
-          <li>LLaMA: <a href="https://arxiv.org/pdf/2302.13971.pdf" target="_blank" rel="noopener noreferrer">https://arxiv.org/pdf/2302.13971.pdf</a></li>
-          <li>LLaMA-Adapter: <a href="https://arxiv.org/pdf/2303.16199.pdf" target="_blank" rel="noopener noreferrer">https://arxiv.org/pdf/2303.16199.pdf</a></li>
-          <li>LLaMA 2: <a href="https://arxiv.org/pdf/2307.09288.pdf" target="_blank" rel="noopener noreferrer">https://arxiv.org/pdf/2307.09288.pdf</a></li>
-          <li>Dataset for RLHF: <a href="https://drive.google.com/file/d/10iR5hKwFqAKhL3umx8muOWSRm7hs5FqX/view" target="_blank" rel="noopener noreferrer">https://drive.google.com/file/d/10iR5hKwFqAKhL3umx8muOWSRm7hs5FqX/view</a></li>
-          <li>FlashAttention: <a href="https://arxiv.org/pdf/2205.14135.pdf" target="_blank" rel="noopener noreferrer">https://arxiv.org/pdf/2205.14135.pdf</a></li>
-          <li>Orca: Progressive Learning from Complex Explanation Traces of GPT-4: <a href="https://arxiv.org/pdf/2306.02707.pdf" target="_blank" rel="noopener noreferrer">https://arxiv.org/pdf/2306.02707.pdf</a></li>
-          <li>Quantization: ?</li>
-      </ul>
+    <ul>
+      <li>Transformers: Attention is All You Need: <a href="https://arxiv.org/pdf/1706.03762.pdf" target="_blank"
+          rel="noopener noreferrer">https://arxiv.org/pdf/1706.03762.pdf</a></li>
+      <li>GPT-3: <a href="https://arxiv.org/pdf/2005.14165.pdf" target="_blank"
+          rel="noopener noreferrer">https://arxiv.org/pdf/2005.14165.pdf</a></li>
+      <li>InstructGPT: <a href="https://arxiv.org/pdf/2203.02155.pdf" target="_blank"
+          rel="noopener noreferrer">https://arxiv.org/pdf/2203.02155.pdf</a></li>
+      <li>Alpaca: A Strong, Replicable Instruction-Following Model: <a
+          href="https://crfm.stanford.edu/2023/03/13/alpaca.html" target="_blank"
+          rel="noopener noreferrer">https://crfm.stanford.edu/2023/03/13/alpaca.html</a></li>
+      <li>Vicuna: <a href="https://lmsys.org/blog/2023-03-30-vicuna/" target="_blank"
+          rel="noopener noreferrer">https://lmsys.org/blog/2023-03-30-vicuna/</a></li>
+      <li>LoRA: Low-Rank Adaptation of Large Language Models: <a href="https://arxiv.org/pdf/2106.09685.pdf"
+          target="_blank" rel="noopener noreferrer">https://arxiv.org/pdf/2106.09685.pdf</a></li>
+      <li>LLaMA: <a href="https://arxiv.org/pdf/2302.13971.pdf" target="_blank"
+          rel="noopener noreferrer">https://arxiv.org/pdf/2302.13971.pdf</a></li>
+      <li>LLaMA-Adapter: <a href="https://arxiv.org/pdf/2303.16199.pdf" target="_blank"
+          rel="noopener noreferrer">https://arxiv.org/pdf/2303.16199.pdf</a></li>
+      <li>LLaMA 2: <a href="https://arxiv.org/pdf/2307.09288.pdf" target="_blank"
+          rel="noopener noreferrer">https://arxiv.org/pdf/2307.09288.pdf</a></li>
+      <li>Dataset for RLHF: <a href="https://drive.google.com/file/d/10iR5hKwFqAKhL3umx8muOWSRm7hs5FqX/view"
+          target="_blank"
+          rel="noopener noreferrer">https://drive.google.com/file/d/10iR5hKwFqAKhL3umx8muOWSRm7hs5FqX/view</a></li>
+      <li>FlashAttention: <a href="https://arxiv.org/pdf/2205.14135.pdf" target="_blank"
+          rel="noopener noreferrer">https://arxiv.org/pdf/2205.14135.pdf</a></li>
+      <li>Orca: Progressive Learning from Complex Explanation Traces of GPT-4: <a
+          href="https://arxiv.org/pdf/2306.02707.pdf" target="_blank"
+          rel="noopener noreferrer">https://arxiv.org/pdf/2306.02707.pdf</a></li>
+      <li>Quantization: ?</li>
+    </ul>
 
-      <p>
-        Über die konkreten Arbeiten und die Liste können wir gerne reden, allerdings möchte ich den Fokus auf Arbeiten legen, die eine Grundlage für
-          Large Language Models bzw. Transformer-basierte Sprachmodelle legen, oder darauf aufbauen.
-      </p>
-      <p>
-          Zum Beispiel haben wir dort GPT-3 und InstructGPT, die beide die Grundlagen für ChatGPT geschafften haben.
-          Beide Paper sind auch von OpenAI. Außerdem gibt es das Äquivalent von Meta: LLaMA und dessen Verbesserungen
-          und Weiterentwicklungen (Vicuna, Alpaca, LLaMA-2). Die restlichen Paper sind Techniken, die im
-          Zusammenhang mit den genannten Modellen stehen, also Optimierungen oder Trainingsmechaniken etc. sind
-          (LoRA, RLHF, FlashAttention, Orca, LLaMA-Adapter). Ich denke, alles, das sich hier in diese Liste gut einfügt, kann
-          eingebracht werden.
-      </p>
-      <p>
-          Nicht alle davon sind wissenschaftliche Papiere, aber vielleicht eignen sie sich trotzdem.
-          Vielleicht aber auch nicht, dann schmeißen wir die eben wieder raus.
-      </p>
-      <h4>Voraussetzungen</h4>
-      <p>
-          Um die Paper zur verstehen, wäre es wichtig, wenn ihr wisst wie man grundsätzlich ein neuronales Netz
-          trainiert. Im Idealfall habt ihr schonmal ein CNN oder RNN Modell trainiert oder benutzt, aber da Transformer
-          anders aufgebaut sind, ist das jetzt kein Muss, würde ich sagen.
-      </p>
+    <p>
+      Über die konkreten Arbeiten und die Liste können wir gerne reden, allerdings möchte ich den Fokus auf Arbeiten
+      legen, die eine Grundlage für
+      Large Language Models bzw. Transformer-basierte Sprachmodelle legen, oder darauf aufbauen.
+    </p>
+    <p>
+      Zum Beispiel haben wir dort GPT-3 und InstructGPT, die beide die Grundlagen für ChatGPT geschafften haben.
+      Beide Paper sind auch von OpenAI. Außerdem gibt es das Äquivalent von Meta: LLaMA und dessen Verbesserungen
+      und Weiterentwicklungen (Vicuna, Alpaca, LLaMA-2). Die restlichen Paper sind Techniken, die im
+      Zusammenhang mit den genannten Modellen stehen, also Optimierungen oder Trainingsmechaniken etc. sind
+      (LoRA, RLHF, FlashAttention, Orca, LLaMA-Adapter). Ich denke, alles, das sich hier in diese Liste gut einfügt,
+      kann
+      eingebracht werden.
+    </p>
+    <p>
+      Nicht alle davon sind wissenschaftliche Papiere, aber vielleicht eignen sie sich trotzdem.
+      Vielleicht aber auch nicht, dann schmeißen wir die eben wieder raus.
+    </p>
+    <h4>Voraussetzungen</h4>
+    <p>
+      Um die Paper zur verstehen, wäre es wichtig, wenn ihr wisst wie man grundsätzlich ein neuronales Netz
+      trainiert. Im Idealfall habt ihr schonmal ein CNN oder RNN Modell trainiert oder benutzt, aber da Transformer
+      anders aufgebaut sind, ist das jetzt kein Muss, würde ich sagen.
+    </p>
+
+    <h4>Letzte Treffen</h4>
+    <ul id="past-meetings-list"></ul>
+
     <h4>Kontakt</h4>
     <p>Anja: <code>reading-group(at)deep.cooking</code></p>
   </main>
@@ -106,4 +159,5 @@
     <p>Made using <a href="https://simplecss.org">Simple.css</a>.</p>
   </footer>
 </body>
+
 </html>

--- a/meetings.json
+++ b/meetings.json
@@ -1,0 +1,16 @@
+{
+  "nextMeeting": {
+    "date": "28.08.2023",
+    "time": "17:00",
+    "paperTitle": "Improving Language Understanding by Generative Pre-Training",
+    "paperLink": "https://cdn.openai.com/research-covers/language-unsupervised/language_understanding_paper.pdf"
+  },
+  "pastMeetings": [
+    {
+      "date": "21.08.2023",
+      "time": "17:00",
+      "paperTitle": "Attention Is All You Need",
+      "paperLink": "https://arxiv.org/pdf/1706.03762.pdf"
+    }
+  ]
+}


### PR DESCRIPTION
In `meetings.json` können wir die kommenden und letzten Treffen tracken. Dann wissen neue Leute, welche Paper wir bereits gelesen haben und was beim nächsten Treffen ansteht. Bestimmt kann man noch irgendwie `.ics` Dateien generieren um die Treffen direkt zum eigenen Kalender hinzuzufügen but i don't know how. 🤷 